### PR TITLE
Setup private k8s docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,51 +35,62 @@ network:
 
 ## Create k8s registry
 
-1. Configure NFS share between master and worker nodes
+### Create registry in http
 
-This should be done in a real k8s cluster, since pod persistent volumes should be mounted from an NFS server
+* Create the folder to store the registry data in the docker host
 
-2. Autentication requirements
+`sudo mkdir -p /opt/registry/data`
 
-* Generate self-signed certificates for private registry
-
-Go to master, node01 and node02
-`sudo mkdir -p /opt/certs /opt/registry/data /opt/registry/auth`
-
-Create key and copy them to all k8s cluster nodes
-```cd /opt
-sudo openssl req -newkey rsa:4096 -nodes -sha256 -keyout \
- ./certs/registry.key -x509 -days 365 -out ./certs/registry.crt
-ls -lrt cert/
+* Create a deployment using the image: registry:2 and the data as volume
+```
+apiVersion: apps/v1
+kind: Deployment
+...
+  volumes:
+      - name: registry-vol
+        hostPath:
+          path: /opt/registry/data
+          type: Directory
+...
+      containers:
+        - image: registry:2
+          name: private-repository-k8s
+          imagePullPolicy: IfNotPresent     
+        volumeMounts:
+          - name: registry-vol
+            mountPath: /var/lib/registry
 ```
 
-Add the certificates to the OS ca
-```sudo cp /opt/certs/registry.crt /usr/local/share/ca-certificates/
-sudo update-ca-certificates
-sudo systemctl restart docker
-```
+Start the registry Deployment
 
-* Add user/password for docker login
-
-htpasswd -cB vi /opt/registry/auth/htpasswd admin
-(type password)
-
-* Copy the /opt folders to the node0x and repeat the update OS certificates step
-
-3. Deploy private registry as deployment via yaml file
-
-Start the registry Deployment (mounting the (/opt created folders))
 `kubectl create -f private-registry.yaml`
 
 Check all is up and running
+
 `kubectl get deployments private-repository-k8s`
 
 `kubectl get pods | grep -i private-repo`
 
+* Create a service to expose the registry
 
-4. Expose registry deployment as a nodeport service type
+```
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: private-repository-k8s
+  name: private-repository-k8s
+spec:
+  ports:
+  - port: 5000
+    nodePort: 31320
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: private-repository-k8s
+  type: NodePort
+```
 
-Expose registry deployment as a nodeport service type
 `kubectl create -f private-registry-svc.yaml`
 
 ```
@@ -87,24 +98,124 @@ NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)       
 private-repository-k8s   NodePort    10.97.251.95   <none>        5000:31320/TCP   46s
 ```
 
-5. Test and Use private docker registry in k8s
+* Add master-node:31320 as a insecure-registry and restart the docker service
+```
+$ sudo vi /lib/systemd/system/docker.service
+ExecStart=/usr/bin/dockerd -H fd:// --insecure-registry master-node:31320 --containerd=/run/containerd/containerd.sock
+$ sudo service docker restart
+```
 
-`sudo docker login -uadmin -ppassword master-node:31320`
+* Validate registry connectivity
 
-6. Push docker image to private repo
+`$ curl -v master-node:31320`
+
+`$ docker login master-node:31320`
+
+### Add security options to support https
+
+* Generate self-signed certificates for private registry
+
+```
+mkdir /opt/certs
+cd /opt/
+
+sudo openssl req -newkey rsa:4096 -nodes -sha256 -keyout ./certs/registry.key -x509 -days 365 -subj "/CN=master-node" -addext "subjectAltName = DNS:master-node"-out ./certs/registry.crt
+```
+
+Check the crt contents with `openssl x509 -in certs/registry.crt -text`
+
+Copy the certificates in other k8s nodes to /opt/certs
+
+* Add the certificate in all k8 cluster nodes
+
+```
+sudo cp /opt/certs/registry.crt /usr/share/ca-certificates/registry.crt
+sudo update-ca-certificates (or sudo dpkg-reconfigure ca-certificates)
+```
+
+* Add certificate to docker
+
+```
+sudo mkdir /etc/docker/certs.d/master-node:31320
+sudo cp /opt/certs/registry.crt /etc/docker/certs.d/master-node\:31320/ca.crt
+sudo service docker restart
+```
+
+* Add user/password for docker login
+
+htpasswd -cB vi /opt/registry/auth/htpasswd admin
+(type password, e.g. password)
+
+Copy htpasswd file to all k8s nodes under /opt/registry/auth/
+
+* Replace the deployment with one using certificate and htpasswd
+
+```
+    volumes:
+      - name: certs-vol
+        hostPath:
+          path: /opt/certs
+          type: Directory
+      - name: registry-vol
+        hostPath:
+          path: /opt/registry/data
+          type: Directory
+      - name: auth-vol
+        hostPath:
+          path: /opt/registry/auth
+          type: Directory
+...
+      containers:
+        - image: registry:2
+          name: private-repository-k8s
+          imagePullPolicy: IfNotPresent          
+          env:
+          - name: REGISTRY_AUTH
+            value: "htpasswd"
+          - name: REGISTRY_AUTH_HTPASSWD_REALM
+            value: "Registry Realm"
+          - name: REGISTRY_AUTH_HTPASSWD_PATH
+            value: /auth/htpasswd
+          - name: REGISTRY_HTTP_TLS_CERTIFICATE
+            value: "/certs/registry.crt"
+          - name: REGISTRY_HTTP_TLS_KEY
+            value: "/certs/registry.key"
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+          - name: certs-vol
+            mountPath: /certs
+          - name: registry-vol
+            mountPath: /var/lib/registry
+          - name: auth-vol
+            mountPath: /auth
+```
+
+* Validate the registry is available
+
+The https domain can be reached `curl https://master-node:31320/v2/_catalog -u admin:password`
+
+The docker registry can be logged in with `docker login master-node:31320`
+
+### Use images from the private registry
+
+* Build the image and push it to the private repo
 
 Build the docker from the master node and add it to the private registry
-`sudo docker build -t redis-pub .`
+```
+sudo docker build -t redis-pub .
 
-`sudo docker tag redis-pub:latest master-node:31320/redis-pub:1.0`
+sudo docker login master-node:31320
+sudo docker tag redis-pub:latest master-node:31320/redis-pub:latest
+sudo docker push master-node:31320/redis-pub:latest
+```
 
-`sudo docker push master-node:31320/redis-pub:1.0`
+* Create a **secret** from the docker config
 
-7. Create pod using the private registry
-
-* Create a secret (e.g. registrypullsecret) using the config.json
-
-`kubectl create secret docker-registry registrypullsecret --docker-server=master-node:31320 --docker-username=admin --docker-password=password`
+```
+$ sudo kubectl create secret generic regcred --from-file=.dockerconfigjson=/home/vagrant/.docker/config.json --type=kubernetes.io/dockerconfigjson
+$ kubectl get secret regcred --output=yaml
+```
 
 * Use private registry in the pod yaml
 
@@ -113,7 +224,19 @@ containers:
   - name: redis-publisher
     image: master-node:31320/redis-pub:1.0
   imagePullSecrets:
-  - name: registrypullsecret
+  - name: regcred
+```
+
+Confirm that the docker image is succesfully pulled with `docker describe pod/redis-publisher
+```
+Events:
+  Type    Reason     Age   From               Message
+  ----    ------     ----  ----               -------
+  Normal  Scheduled  22s   default-scheduler  Successfully assigned default/redis-publisher to worker-node02
+  Normal  Pulling    21s   kubelet            Pulling image "master-node:31320/redis-pub:latest"
+  Normal  Pulled     1s    kubelet            Successfully pulled image "master-node:31320/redis-pub:latest" in 19.926812435s
+  Normal  Created    1s    kubelet            Created container redis-publisher
+  Normal  Started    0s    kubelet            Started container redis-publisher
 ```
 
 ## Check DNS k8s service health

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ https://devopscube.com/kubernetes-cluster-vagrant/
 
 # K8s setup
 
+## Setup master node dns nameserver
+
+This was required because when building a docker using the npm install, the https://registry.npmjs.org was not resolved
+
+Master node is ubuntu, hence
+
+```$ sudo nano /etc/netplan/01-netcfg.yaml
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      nameservers:
+        addresses: [8.8.8.8, 8.8.4.4]
+```
+
 ## Create k8s registry
 
 1. Configure NFS share between master and worker nodes
@@ -80,9 +96,9 @@ private-repository-k8s   NodePort    10.97.251.95   <none>        5000:31320/TCP
 Build the docker from the master node and add it to the private registry
 `sudo docker build -t redis-pub .`
 
-`$ sudo docker tag redis-pub:latest master-node:31320/redis-pub:1.0`
+`sudo docker tag redis-pub:latest master-node:31320/redis-pub:1.0`
 
-`$ sudo docker push master-node:31320/redis-pub:1.0`
+`sudo docker push master-node:31320/redis-pub:1.0`
 
 7. Create pod using the private registry
 

--- a/ambassadors/redis-publisher/Dockerfile
+++ b/ambassadors/redis-publisher/Dockerfile
@@ -3,7 +3,7 @@ FROM node:latest
 WORKDIR /app
 COPY . .
 
-RUN npm install
+RUN npm install && npm install redis
 
 ENV PORT=8080
 EXPOSE ${PORT}

--- a/ambassadors/redis-publisher/package.json
+++ b/ambassadors/redis-publisher/package.json
@@ -1,11 +1,14 @@
 {
   "name": "redis-publisher",
   "version": "1.0.0",
-  "description": "",
   "main": "publisher.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "redis": "^3.1.2"
+  },
+  "description": ""
 }

--- a/ambassadors/redis-publisher/redis-publisher-pod.yaml
+++ b/ambassadors/redis-publisher/redis-publisher-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: redis-publisher
-    image: master-node:31320/redis-pub:1.0
+    image: master-node:31320/redis-pub:latest
   imagePullSecrets:
-  - name: registrypullsecret
+  - name: regcred


### PR DESCRIPTION
Add openssl certificate to support docker registry https. This is required to function with k8s
Change Readme to describe step by step, from creating the registry to load images and use them on pod instances